### PR TITLE
QOL-8091 update PlsPlusAddress behaviour

### DIFF
--- a/src/components/PlsPlusAddress/PlsPlusAddress.js
+++ b/src/components/PlsPlusAddress/PlsPlusAddress.js
@@ -461,6 +461,7 @@ export class PlsPlusAddress extends ContainerComponent {
                 childElement.value = component.dataValue;
               });
             });
+            this.redraw();
           },
         });
 
@@ -571,6 +572,7 @@ export class PlsPlusAddress extends ContainerComponent {
     });
 
     this.updateRemoveIcon(index);
+    this.redraw();
   }
 
   getDisplayValue(value = this.address) {

--- a/src/components/PlsPlusAddress/PlsPlusAddress.test.js
+++ b/src/components/PlsPlusAddress/PlsPlusAddress.test.js
@@ -99,12 +99,24 @@ test("PlsPlusAddress is rendered", async () => {
     form: formSettings,
   });
   document.body.append(form);
+
   const label = await findByText(form, "PlsPlus Address field");
   expect(label).toBeVisible();
-  const autocomplete = form.querySelector("input[name='data[plsplusaddress]']");
-  expect(autocomplete).toBeVisible();
+  await testWait();
+  expect(
+    form.querySelector("input[name='data[plsplusaddress][address1]']")
+  ).toBeNull();
+
+  // user clicks on the manual mode checkbox
   const checkbox = form.querySelector("input[ref='modeSwitcher']");
-  expect(checkbox).toBeVisible();
+  expect(checkbox).not.toBeChecked();
+  await userEvent.click(checkbox);
+  await testWait();
+
+  // autocomplete should be disabled
+  const autocomplete = form.querySelector("input[ref='searchInput']");
+  expect(autocomplete).toBeDisabled();
+
   const address1 = form.querySelector(
     "input[name='data[plsplusaddress][address1]']"
   );
@@ -184,10 +196,9 @@ test("PlsPlusAddress remove button is functional", async () => {
   await testWait();
 
   // address1 automatically parsed and populated
-  const address1 = form.querySelector(
-    "input[name='data[plsplusaddress][address1]']"
-  );
-  expect(address1).toHaveValue(
+  expect(
+    form.querySelector("input[name='data[plsplusaddress][address1]']")
+  ).toHaveValue(
     fixtures[`formData${caseName}`].plsplusaddress.address.address1
   );
   await testWait();
@@ -198,11 +209,15 @@ test("PlsPlusAddress remove button is functional", async () => {
   );
 
   // user clicks on remove button
-  await userEvent.click(removeButton);
-
-  // fields should be cleared
-  expect(address1).toHaveValue("");
-  expect(autocomplete).toHaveValue("");
+  await userEvent.click(form.querySelector("i[ref='removeValueIcon']"));
+  await testWait();
+  // sub-address fields should be hidden, autocomplete field should be empty
+  expect(
+    form.querySelector("input[name='data[plsplusaddress][address1]']")
+  ).toBeNull();
+  expect(form.querySelector("input[name='data[plsplusaddress]']")).toHaveValue(
+    ""
+  );
 
   // form should be invalid if submitted
   const button = getByText(form, "Submit");

--- a/src/templates/bootstrap/plsPlusAddress/form.ejs
+++ b/src/templates/bootstrap/plsPlusAddress/form.ejs
@@ -34,13 +34,14 @@
     </label>
   </div>
 {% } %}
-{% if (ctx.self.manualModeEnabled) { %}
+{% if (ctx.self.manualModeEnabled && ( ctx.mode.manual || ctx.displayValue)) { %}
   <div ref="{{ ctx.nestedKey }}">
     {{ ctx.children }}
   </div>
 {% } %}
 {% if (ctx.mode.manual) { %}
 <div>
-  <p><a href="#" target="_blank">Please take part to improve our address database if we couldn't find your address.</a></p>
+  <!-- Todo Link/function to improve the address database -->
+  <!-- <p><a href="#" target="_blank">Please take part to improve our address database if we couldn't find your address.</a></p> -->
 </div>
 {% } %}


### PR DESCRIPTION
final touch on the PlsPlusAddress component
- show sub-address fields only if manual checkbox is checked or autocomplete address is selected
- remove the link placeholder for data improvement, will create a new ticket for this functionality
- update tests