### PR TITLE
QOL-8650 improve createFormOptions and createFormController

### DIFF
--- a/src/matrixHelpers/FormioLoader/FormioLoader.stories.mdx
+++ b/src/matrixHelpers/FormioLoader/FormioLoader.stories.mdx
@@ -70,15 +70,17 @@ This is useful if you want to dynamically inject a form element. (Although the `
 
 ### Options:
 
-| Option           | Description                                                 | Example                        |
-| ---------------- | ----------------------------------------------------------- | ------------------------------ |
-| projectName      | Formio project name                                         | dev-svcwlpuksmwawwk            |
-| formName         | Formio form name                                            | plsPlusFormDemo                |
-| envUrl           | domain name of the Formio endpoint                          | api.forms.platforms.qld.gov.au |
-| formConfirmation | redirect page for wizard after submission                   | /                              |
-| formRevision     | form revision number                                        | 1                              |
-| pdfDownload      | Does the form involve pdf download                          | no                             |
-| namespace        | Namespace of the form for creating key for token, user, etc | any string                     |
+| Option               | Description                                                                                                                                  | Example                                                       |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| projectName          | Formio project name                                                                                                                          | dev-svcwlpuksmwawwk                                           |
+| formName             | Formio form name                                                                                                                             | plsPlusFormDemo                                               |
+| envUrl               | domain name of the Formio endpoint                                                                                                           | api.forms.platforms.qld.gov.au                                |
+| formConfirmation     | redirect page for wizard after submission                                                                                                    | /                                                             |
+| formRevision         | form revision number                                                                                                                         | 1                                                             |
+| pdfDownload          | Does the form involve pdf download                                                                                                           | no                                                            |
+| namespace            | Namespace of the form for creating key for token, user, etc                                                                                  | any string                                                    |
+| createFormOptions    | function that returns [options](https://help.form.io/developers/form-renderer#form-renderer-options) to be passed to the createForm function | ({ envUrl, projectName, formName, defaultOptions }) => object |
+| createFormController | custom form controller function                                                                                                              | ({ envUrl, projectName, formName, form }) => void)            |
 
 <Canvas withSource="open">
   <Story name="initFormioInstanceMethod">
@@ -99,25 +101,32 @@ This is useful if you want to dynamically inject a form element. (Although the `
   </Story>
 </Canvas>
 
-## Custom createForm options with webhook
+## Custom createForm options with `createFormOptions` hook
 
-You can create a webhook function `window.formioCreateFormOptions` to customise the [options](https://help.form.io/developers/form-renderer#form-renderer-options) pass to the each `createForm` function.
-Also you could pass different options base on different project or form.
+You can create a hook function `createFormOptions` to customise the [options](https://help.form.io/developers/form-renderer#form-renderer-options).
+Within the function you could pass different options base on different project or form.
 
-This webhook function can be placed in anywhere of your page. The example below will add the custom options to every forms in the page.
+The example below will add the custom options to every forms in the page.
 
 ```jsx
-window.formioCreateFormOptions = () => {
+const customFn = () => {
   return {
     readOnly: true,
   };
 };
+FormioLoader.initFormioInstance(elem, {
+  projectName: "dev-svcwlpuksmwawwk",
+  formName: "plsPlusFormDemo",
+  envUrl: "api.forms.platforms.qld.gov.au",
+  pdfDownload: "no",
+  createFormOptions: customFn,
+});
 ```
 
-The example below only add the custom options to certain project or form.
+The example below only add the custom options to certain project or form with a single hook function.
 
 ```jsx
-window.formioCreateFormOptions = ({ envUrl, projectName, formName }) => {
+const customFn = ({ envUrl, projectName, formName }) => {
   if ({ envUrl === "api.forms.platforms.qld.gov.au") {
     return {
       readOnly: true,
@@ -135,6 +144,20 @@ window.formioCreateFormOptions = ({ envUrl, projectName, formName }) => {
   }
   return {};
 };
+FormioLoader.initFormioInstance(elem1, {
+  projectName: "project1",
+  formName: "form1",
+  envUrl: "api.forms.platforms.qld.gov.au",
+  pdfDownload: "no",
+  createFormOptions: customFn
+});
+FormioLoader.initFormioInstance(elem2, {
+  projectName: "project2",
+  formName: "form2",
+  envUrl: "api.forms.platforms.qld.gov.au",
+  pdfDownload: "no",
+  createFormOptions: customFn
+});
 ```
 
 Please refer to https://help.form.io/developers/form-renderer#form-renderer-options for available options.
@@ -142,21 +165,14 @@ Please refer to https://help.form.io/developers/form-renderer#form-renderer-opti
 Below is a full example:
 
 <Canvas withSource="open">
-  <Story name="custom CreateForm Options Webhook">
+  <Story name="custom CreateForm Options hook">
     {() => {
-      window.formioCreateFormOptions = ({
-        projectName,
-        formName,
-        defaultOptions,
-      }) => {
-        if (projectName === "dev-svcwlpuksmwawwk" && formName === "testing1") {
-          // you can see the defaultOptions in the browser's inspector, and possible to manipulate and return it.
-          console.info("defaultOptions:", defaultOptions);
-          return {
-            readOnly: true,
-          };
-        }
-        return {};
+      const customFn = ({ defaultOptions }) => {
+        // you can see the defaultOptions in the browser's inspector, and possible to manipulate and return it.
+        console.info("defaultOptions:", defaultOptions);
+        return {
+          readOnly: true,
+        };
       };
       setTimeout(() => {
         const elem = document.getElementById("formio-options");
@@ -165,6 +181,7 @@ Below is a full example:
           formName: "testing1",
           envUrl: "api.forms.platforms.qld.gov.au",
           pdfDownload: "no",
+          createFormOptions: customFn,
         });
       });
       return `
@@ -174,35 +191,50 @@ Below is a full example:
   </Story>
 </Canvas>
 
-## Controlling the Form with JavaScript
+## Controlling the Form with JavaScript with `createFormController` hook
 
-You can use the webhook function `window.formioCreateFormController` to control the form after initialisation, as described in https://help.form.io/developers/form-renderer#controlling-the-form-with-javascript.
-
-This webhook function can be placed in anywhere of your page. The example below will add the custom options to every forms in the page.
+You can create a hook function `createFormController` to customise the [form controller](https://help.form.io/developers/form-renderer#controlling-the-form-with-javascript).
+Within the function you could customise the controller base on different project or form.
 
 ```jsx
-window.formioCreateFormController = ({ form }) => {
+const customFn = ({ form }) => {
   form.on("change", (e) => {
     console.info("onChange", e);
   });
 };
+FormioLoader.initFormioInstance(elem, {
+  projectName: "dev-svcwlpuksmwawwk",
+  formName: "plsPlusFormDemo",
+  envUrl: "api.forms.platforms.qld.gov.au",
+  pdfDownload: "no",
+  createFormController: customFn,
+});
 ```
 
 The example below only control the form to certain project or form.
 
 ```jsx
-window.formioCreateFormController = ({
-  envUrl,
-  projectName,
-  formName,
-  form,
-}) => {
+const customFn = ({ envUrl, projectName, formName, form }) => {
   if (projectName === "project2" && formName === "form2") {
     form.on("change", (e) => {
       console.info("onChange", e);
     });
   }
 };
+FormioLoader.initFormioInstance(elem1, {
+  projectName: "project1",
+  formName: "form1",
+  envUrl: "api.forms.platforms.qld.gov.au",
+  pdfDownload: "no",
+  createFormOptions: customFn,
+});
+FormioLoader.initFormioInstance(elem2, {
+  projectName: "project2",
+  formName: "form2",
+  envUrl: "api.forms.platforms.qld.gov.au",
+  pdfDownload: "no",
+  createFormOptions: customFn,
+});
 ```
 
 Please refer to https://help.form.io/developers/form-renderer#controlling-the-form-with-javascript for more examples.
@@ -210,15 +242,13 @@ Please refer to https://help.form.io/developers/form-renderer#controlling-the-fo
 Below is a full example:
 
 <Canvas withSource="open">
-  <Story name="custom CreateForm controller Webhook">
+  <Story name="custom CreateForm controller hook">
     {() => {
-      window.formioCreateFormController = ({ projectName, formName, form }) => {
-        if (projectName === "dev-svcwlpuksmwawwk" && formName === "testing2") {
-          form.on("change", (e) => {
-            // you can see the data object in the browser's inspector whenever you change the field value.
-            console.info("onChange", e.data);
-          });
-        }
+      const customFn = ({ form }) => {
+        form.on("change", (e) => {
+          // you can see the data object in the browser's inspector whenever you change the field value.
+          console.info("onChange", e.data);
+        });
       };
       setTimeout(() => {
         const elem = document.getElementById("formio-controller");
@@ -227,6 +257,7 @@ Below is a full example:
           formName: "testing2",
           envUrl: "api.forms.platforms.qld.gov.au",
           pdfDownload: "no",
+          createFormController: customFn,
         });
       });
       return `

--- a/src/matrixHelpers/FormioLoader/FormioLoader.test.js
+++ b/src/matrixHelpers/FormioLoader/FormioLoader.test.js
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom";
+import userEvent from "@testing-library/user-event";
 import { findByText } from "@testing-library/dom";
 import * as FormioLoader from "./index";
 import { testWait } from "../../utils";
@@ -41,8 +42,8 @@ test("FormioLoader is initiated with invalid div", async () => {
 });
 
 // Smoke test
-test("FormioLoader with custom option webhook", async () => {
-  window.formioCreateFormOptions = () => {
+test("FormioLoader with custom option hook", async () => {
+  window.customOptionsFn = () => {
     return {
       readOnly: true,
     };
@@ -59,6 +60,7 @@ test("FormioLoader with custom option webhook", async () => {
     data-formio-env-url="api.forms.platforms.qld.gov.au" 
     data-formio-pdf-download="no" 
     data-formio-namespace="" 
+    data-formio-createForm-options="customOptionsFn"
   ></div>
 `;
   document.body.append(div);
@@ -71,4 +73,56 @@ test("FormioLoader with custom option webhook", async () => {
   const autocomplete = div.querySelector("input[name='data[address]']");
   expect(autocomplete).toBeVisible();
   expect(autocomplete).toBeDisabled();
+});
+
+// Smoke test
+test("FormioLoader with custom controller hook", async () => {
+  let data = {};
+  window.customControllerFn = ({ form }) => {
+    form.on("change", (e) => {
+      data = e.data;
+    });
+  };
+
+  const div = document.createElement("div");
+  div.innerHTML = `
+  <div id="formio" 
+    data-formio 
+    data-formio-project-name="dev-svcwlpuksmwawwk" 
+    data-formio-form-name="plsPlusFormDemo" 
+    data-formio-form-confirmation="" 
+    data-formio-form-revision="" 
+    data-formio-env-url="api.forms.platforms.qld.gov.au" 
+    data-formio-pdf-download="no" 
+    data-formio-namespace="" 
+    data-formio-createForm-controller="customControllerFn"
+  ></div>
+`;
+  document.body.append(div);
+  FormioLoader.initFormio();
+  jest.spyOn(Formio, "makeRequest").mockResolvedValueOnce(formioRes);
+
+  const label = await findByText(div, "Address");
+  expect(label).toBeVisible();
+
+  const checkbox = div.querySelector("input[ref='modeSwitcher']");
+  expect(checkbox).not.toBeChecked();
+  await userEvent.click(checkbox);
+  await testWait();
+  expect(data).toEqual({
+    address: {
+      address: {
+        address1: "",
+        address2: "",
+        address3: "",
+        autocompleteAddress: "",
+        city: "",
+        postcode: "",
+        selectedAddress: "",
+        state: "QLD",
+      },
+      mode: "autocomplete",
+    },
+    submit: false,
+  });
 });

--- a/src/matrixHelpers/FormioScript/FormioScript.stories.mdx
+++ b/src/matrixHelpers/FormioScript/FormioScript.stories.mdx
@@ -39,8 +39,13 @@ Simply include it in your application and it will search through the page with F
 <script>
   Formio.createForm(
     document.getElementById("formio1"),
-    "https://api.forms.platforms.qld.gov.au/dev-svcwlpuksmwawwk/plsPlusFormDemo"
-  );
+    "https://api.forms.platforms.qld.gov.au/dev-svcwlpuksmwawwk/plsPlusFormDemo",
+    {readOnly: true}
+  ).then((form) {
+    form.on("change", (e) => {
+      console.info("onChange", e);
+    });
+  });
   Formio.createForm(
     document.getElementById("formio2"),
     "https://api.forms.platforms.qld.gov.au/dev-svcwlpuksmwawwk/testing"
@@ -57,6 +62,8 @@ Simply include it in your application and it will search through the page with F
   data-formio-project-name="dev-svcwlpuksmwawwk"
   data-formio-form-name="plsPlusFormDemo"
   data-formio-env-url="api.forms.platforms.qld.gov.au"
+  data-formio-createForm-options="customFn1"
+  data-formio-createForm-controller="customFn2"
 ></div>
 <div
   class="qg-forms-v2"
@@ -65,6 +72,16 @@ Simply include it in your application and it will search through the page with F
   data-formio-form-name="testing"
   data-formio-env-url="api.forms.platforms.qld.gov.au"
 ></div>
+<script>
+  window.customFn1 = () => ({
+    readOnly: true,
+  });
+  window.customFn2 = ({ form }) => {
+    form.on("change", (e) => {
+      console.info("onChange", e);
+    });
+  };
+</script>
 <script src="https://static.qgov.net.au/formio-qld/v1/v1.x.x-latest/formio-script.prod.min.js"></script>
 ```
 
@@ -90,8 +107,47 @@ Please refer to Squiz Matrix asset #249261.
 
 ### How to pass custom createForm options?
 
-You can use webhook function `window.formioCreateFormOptions` to customise the form options, please refer to [/docs/helpers-formioloader--custom-create-form-options-webhook](/docs/helpers-formioloader--custom-create-form-options-webhook) for details.
+You can add `data-formio-createForm-options` in the div's data attribute with the function name you want to return the custom options.
+
+```html
+<div
+  class="qg-forms-v2"
+  data-formio
+  data-formio-project-name="dev-svcwlpuksmwawwk"
+  data-formio-form-name="plsPlusFormDemo"
+  data-formio-env-url="api.forms.platforms.qld.gov.au"
+  data-formio-createForm-options="customFn1"
+></div>
+<script src="https://static.qgov.net.au/formio-qld/v1/v1.x.x-latest/formio-script.prod.min.js"></script>
+<script>
+  window.customFn1 = ({ envUrl, projectName, formName }) => {
+    return {
+      readOnly: true,
+    };
+  };
+</script>
+```
 
 ### How to customise createForm form controller?
 
-You can use webhook function `window.formioCreateFormController` to customise the form controller, please refer to [/docs/helpers-formioloader--custom-create-form-controller-webhook](/docs/helpers-formioloader--custom-create-form-controller-webhook) for details.
+You can add `data-formio-createForm-controller` in the div's data attribute with the function name you want to customise the form controller.
+
+```html
+<div
+  class="qg-forms-v2"
+  data-formio
+  data-formio-project-name="dev-svcwlpuksmwawwk"
+  data-formio-form-name="plsPlusFormDemo"
+  data-formio-env-url="api.forms.platforms.qld.gov.au"
+  data-formio-createForm-controller="customFn2"
+></div>
+<script src="https://static.qgov.net.au/formio-qld/v1/v1.x.x-latest/formio-script.prod.min.js"></script>
+<script>
+  window.customFn2 = ({ envUrl, projectName, formName, form }) => {
+    form.on("change", (e) => {
+      console.info("onChange", e);
+    });
+  };
+  FormioScript.init();
+</script>
+```

--- a/src/matrixHelpers/FormioScript/index.js
+++ b/src/matrixHelpers/FormioScript/index.js
@@ -73,7 +73,10 @@ export const getDefaultScripts = ({ subdomain, version = defaultVersion }) => {
 
 export const initScript = (scripts) => {
   if (window.formioScriptLoaded) {
-    if (typeof FormioLoader !== "undefined") FormioLoader.initFormio();
+    if (typeof FormioLoader !== "undefined")
+      setTimeout(() => {
+        FormioLoader.initFormio();
+      });
   } else {
     window.formioScriptLoaded = true;
     createScripts(scripts);


### PR DESCRIPTION
- improve flexibility to customise options and controller in createForm function
- expose options and controller with `createFormOptions` and `createFormController` props in `initFormioInstance`
- pass `createFormOptions` and `createFormController` by data-attribute of the container div

now user can either define indivdual hook function or a global hook function to customise options and controller in any form instances, thus solve the problem of overlapping hook functions in https://github.com/qld-gov-au/formio/pull/16#discussion_r846856468