### PR TITLE
update storybook webpack

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -24,7 +24,17 @@ module.exports = {
       test: /\.(s(a|c)ss)$/,
       use: ["style-loader", "css-loader", "sass-loader"],
     });
+    config.module.rules.find(
+      (item) => item.type === "asset/resource"
+    ).generator.filename = "static/media/storybook-[name].[contenthash:8][ext]";
+    config.module.rules.find(
+      (item) => item.type === "asset"
+    ).generator.filename = "static/media/storybook-[name].[contenthash:8][ext]";
     config.mode = "development";
+    config.output = {
+      ...config.output,
+      filename: "storybook-[name].[contenthash:8].iframe.bundle.js",
+    };
     return config;
   },
 };


### PR DESCRIPTION
fix storybook deployment
files with `node_modules` prefix will be excluded in jekyll build