### PR TITLE
set projectURl and baseUrl on pre-request

### DIFF
--- a/src/helpers/FormioLoader/FormioLoader.js
+++ b/src/helpers/FormioLoader/FormioLoader.js
@@ -15,6 +15,8 @@ const requestPluginHandler = (requestArgs, opts) => {
       requestArgs.opts.base = requestArgs.formio.options.base;
       requestArgs.opts.project = requestArgs.formio.options.project;
       requestArgs.opts.namespace = requestArgs.formio.options.namespace;
+      Formio.setProjectUrl(requestArgs.formio.options.project);
+      Formio.setBaseUrl(requestArgs.formio.options.base);
     }
   }
 


### PR DESCRIPTION
this will fix the URL construction of data resource request from a select doesn't contain the projectId
eg. 
before:
api.forms.platforms.qld.gov.au/form/627dd82559d38c6f610de8c7/submission?limit=10000&skip=0&data.label__regex=s&sort=data.submissionOrderBy
after:
api.forms.platforms.qld.gov.au/**dev-zmuchxwdmdytntr**/form/627dd82559d38c6f610de8c7/submission?limit=10000&skip=0&sort=data.submissionOrderBy