### PR TITLE
add support to iOS 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "url": "https://github.com/qld-gov-au/formio.git"
   },
   "browserslist": [
-    "last 3 Chrome versions"
+    "last 3 Chrome versions",
+    "iOS >= 12"
   ],
   "scripts": {
     "storybook": "start-storybook -p 6006",


### PR DESCRIPTION
add iOS 12 support to the build assets
hotfix for the iOS 12 issue addressed in the contact us page tseting