### PR TITLE
QOLDEV-539 new variable formIOGitBridgeID added to avoid variable clash

### DIFF
--- a/src/helpers/FormioScript/index.gitbridge.js
+++ b/src/helpers/FormioScript/index.gitbridge.js
@@ -1,6 +1,6 @@
 import { initScript } from ".";
 
-const version = window.formioQldCdnVersion || "248740";
+const version = window.formIOGitBridgeID || "248740";
 
 const scripts = [
   {


### PR DESCRIPTION
(Squiz side)
![image](https://github.com/qld-gov-au/formio/assets/126438309/cb7c6962-45e7-4449-81ef-448d1776deb6)

Background: 
formioQldCdnVersion was used for multiple purposes. 
This change adds a new variable to help handle GitBridge paths in Squiz.   