### PR TITLE
QOLDEV-666 Styling dropdown

### DIFF
--- a/src/components/Dropdown/sass/dropdown.swe.scss
+++ b/src/components/Dropdown/sass/dropdown.swe.scss
@@ -1,0 +1,5 @@
+.formio-choices {
+    .dropdown {
+        height: 44px;
+    }
+}

--- a/src/sass/formio.form.swe.scss
+++ b/src/sass/formio.form.swe.scss
@@ -4,4 +4,5 @@
 @import '../components/PlsPlusAddress/sass/plsPlusAddress.swe.scss';
 @import '../components/Button/sass/button.swe.scss';
 @import '../components/DataGrid/sass/datagrid.swe.scss';
+@import '../components/Dropdown/sass/dropdown.swe.scss';
 @import '../components/Radio/sass/radio.swe.scss';


### PR DESCRIPTION
https://oss-uat.clients.squiz.net/law/assets/forms/formio-test/vaq/apply-for-financial-assistance

**Before:**
![image](https://github.com/qld-gov-au/formio/assets/126438691/37c530c9-5b03-4259-8761-5119facd59d0)


**After:**
![image](https://github.com/qld-gov-au/formio/assets/126438691/2befb888-4249-4b8d-b191-db611b6da992)


This change will also make the dropdown's height similar to the dropdowns within datagrids.